### PR TITLE
Remove emoji detection script from oembed requests

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -16,6 +16,7 @@ function remove_extra_emoji_handling() {
 	// into Twemoji images.
 	remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
 	remove_action( 'admin_print_scripts', 'print_emoji_detection_script' );
+	remove_action( 'embed_head', 'print_emoji_detection_script' );
 
 	// Don't output the inline styles applied to Twemoji images by default.
 	remove_action( 'wp_print_styles', 'print_emoji_styles' );


### PR DESCRIPTION
The styles were removed earlier and the resulting images took up the entire iframe on sites that embedded posts. 😂