### PR TITLE
Enqueue an admin stylesheet to fix webmention avatar display

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -1,0 +1,5 @@
+/* WordPress does not account for custom comment types
+ * with avatars. */
+.avatar ~ .dashboard-comment-wrap {
+    padding-left: 63px;
+}

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace JWC\Admin;
+
+add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_dashboard_css' );
+
+/**
+ * Enqueue a custom stylesheet on the dashboard.
+ */
+function enqueue_dashboard_css() {
+	if ( get_current_screen() && 'dashboard' === get_current_screen()->id ) {
+		wp_enqueue_style(
+			'jwc-dashboard',
+			plugin_dir_url( __DIR__ ) . '/css/dashboard.css',
+			false
+		);
+	}
+}

--- a/plugin.php
+++ b/plugin.php
@@ -29,3 +29,4 @@ if ( version_compare( PHP_VERSION, '5.6', '<' ) ) {
 }
 
 require_once __DIR__ . '/includes/common.php';
+require_once __DIR__ . '/includes/admin.php';


### PR DESCRIPTION
WordPress core adds 63px of padding when `.has-avatar` is added to the comment wrapping `div`, but will only apply `.has-avatar` for the standard comment type. There is no filter for a custom comment type to inject class names here, so we have to get a bit hacky.