### PR TITLE
Remove unused block patterns registered by parent theme, core

### DIFF
--- a/includes/block-patterns.php
+++ b/includes/block-patterns.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace JWC\BlockPatterns;
+
+// WordPress core registers default patterns on priority 11.
+add_action( 'init', __NAMESPACE__ . '\unregister_block_patterns', 11 );
+
+/**
+ * Unregister any block patterns that I don't use.
+ *
+ * This may (?) speed up the editor a bit and does (certainly) clean
+ * up the console log, which is currently full of block transformation
+ * notices for these patterns.
+ */
+function unregister_block_patterns() {
+	$patterns = array(
+		// Patterns registered in Twenty Twenty One
+		'twentytwentyone/large-text',
+		'twentytwentyone/links-area',
+		'twentytwentyone/media-text-article-title',
+		'twentytwentyone/overlapping-images',
+		'twentytwentyone/two-images-showcase',
+		'twentytwentyone/overlapping-images-and-text',
+		'twentytwentyone/contact-information',
+		'twentytwentyone/portfolio-list',
+
+		// Patterns registered in WordPress Core.
+		'core/text-two-columns',
+		'core/two-buttons',
+		'core/two-images',
+		'core/text-two-columns-with-images',
+		'core/text-three-columns-buttons',
+		'core/large-header',
+		'core/large-header-button',
+		'core/three-buttons',
+		'core/heading-paragraph',
+		'core/quote',
+	);
+
+	foreach ( $patterns as $pattern ) {
+		unregister_block_pattern( $pattern );
+	}
+}

--- a/plugin.php
+++ b/plugin.php
@@ -30,3 +30,4 @@ if ( version_compare( PHP_VERSION, '5.6', '<' ) ) {
 
 require_once __DIR__ . '/includes/common.php';
 require_once __DIR__ . '/includes/admin.php';
+require_once __DIR__ . '/includes/block-patterns.php';


### PR DESCRIPTION
I'm not using any of these right now and the console log is full of block transformation notices because of these patterns and how they are rendered.